### PR TITLE
Fix empty key bug in VigenereEncoder

### DIFF
--- a/Algorithms.Tests/Encoders/VigenereEncoderTests.cs
+++ b/Algorithms.Tests/Encoders/VigenereEncoderTests.cs
@@ -1,4 +1,5 @@
-﻿using Algorithms.Encoders;
+﻿using System;
+using Algorithms.Encoders;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -14,7 +15,7 @@ namespace Algorithms.Tests.Encoders
             var random = new Randomizer();
             var encoder = new VigenereEncoder();
             var message = random.GetString();
-            var key = random.GetString(random.Next(0, 1000));
+            var key = random.GetString(random.Next(1, 1000));
 
             // Act
             var encoded = encoder.Encode(message, key);
@@ -22,6 +23,18 @@ namespace Algorithms.Tests.Encoders
 
             // Assert
             Assert.AreEqual(message, decoded);
+        }
+
+        [Test]
+        public static void EmptyKeyThrowsException()
+        {
+            var random = new Randomizer();
+            var encoder = new VigenereEncoder();
+            var message = random.GetString();
+            var key = string.Empty;
+
+            _ = Assert.Throws<ArgumentOutOfRangeException>(() => encoder.Encode(message, key));
+            _ = Assert.Throws<ArgumentOutOfRangeException>(() => encoder.Decode(message, key));
         }
     }
 }

--- a/Algorithms/Encoders/VigenereEncoder.cs
+++ b/Algorithms/Encoders/VigenereEncoder.cs
@@ -54,6 +54,11 @@ namespace Algorithms.Encoders
 
         private string AppendKey(string key, int length)
         {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(key)} must be non-empty string");
+            }
+
             var keyBuilder = new StringBuilder(key, length);
             while (keyBuilder.Length < length)
             {


### PR DESCRIPTION
Fix intermittent bug where Travis build would hang unresponsive. This was due to incorrect handling of an empty key in VIgenere encoder 

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added comments to my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the comments
- [x] I have made corresponding changes to the README.md