### PR TITLE
Change ArrayBaseStack to be O(1) for PUSH

### DIFF
--- a/DataStructures.Tests/ArrayBasedStackTests.cs
+++ b/DataStructures.Tests/ArrayBasedStackTests.cs
@@ -67,5 +67,18 @@ namespace DataStructures.Tests
             stack.Push(4);
             Assert.IsTrue(stack.Peek() == 4);
         }
+
+        [Test]
+        public static void AutomaticResizesTest()
+        {
+            var stack = new ArrayBasedStack<int>();
+            stack.Capacity = 2;
+            stack.Push(0);
+            stack.Push(1);
+            stack.Push(2);
+            stack.Push(3);
+            stack.Push(4);
+            Assert.IsTrue(stack.Capacity > 2);
+        }
     }
 }

--- a/DataStructures/ArrayBasedStack/ArrayBasedStack.cs
+++ b/DataStructures/ArrayBasedStack/ArrayBasedStack.cs
@@ -9,15 +9,22 @@ namespace DataStructures.ArrayBasedStack
     /// <typeparam name="T">Generic Type.</typeparam>
     public class ArrayBasedStack<T>
     {
+        private const int DefaultCapacity = 10;
+
         /// <summary>
         /// <see cref="Array"/> based stack.
         /// </summary>
         private T[] stack;
 
         /// <summary>
+        /// How many items are in the stack right now.
+        /// </summary>
+        private int count;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ArrayBasedStack{T}"/> class.
         /// </summary>
-        public ArrayBasedStack() => stack = Array.Empty<T>();
+        public ArrayBasedStack() => stack = new T[DefaultCapacity];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayBasedStack{T}"/> class.
@@ -42,25 +49,41 @@ namespace DataStructures.ArrayBasedStack
         /// <summary>
         /// Gets the number of elements on the <see cref="ArrayBasedStack{T}"/>.
         /// </summary>
-        public int Count => stack.Length;
+        public int Count => count;
+
+        /// <summary>
+        /// Gets or sets the Capacity of the <see cref="ArrayBasedStack{T}"/>.
+        /// </summary>
+        public int Capacity
+        {
+            get
+            {
+                return stack.Length;
+            }
+
+            set
+            {
+                Array.Resize(ref stack, value);
+            }
+        }
 
         /// <summary>
         /// Removes all items from the <see cref="ArrayBasedStack{T}"/>.
         /// </summary>
-        public void Clear() => Array.Resize(ref stack, 0);
+        public void Clear() => count = 0;
 
         /// <summary>
         /// Determines whether an element is in the <see cref="ArrayBasedStack{T}"/>.
         /// </summary>
         /// <param name="item">The item to locate in the <see cref="ArrayBasedStack{T}"/>.</param>
         /// <returns>True, if the item is in the stack.</returns>
-        public bool Contains(T item) => Array.IndexOf(stack, item) > -1;
+        public bool Contains(T item) => Array.IndexOf(stack, item, 0, count) > -1;
 
         /// <summary>
         /// Returns the item at the top of the <see cref="ArrayBasedStack{T}"/> without removing it.
         /// </summary>
         /// <returns>The item at the top of the <see cref="ArrayBasedStack{T}"/>.</returns>
-        public T Peek() => stack[^1];
+        public T Peek() => stack[count - 1];
 
         /// <summary>
         /// Removes and returns the item at the top of the <see cref="ArrayBasedStack{T}"/>.
@@ -68,8 +91,8 @@ namespace DataStructures.ArrayBasedStack
         /// <returns>The item removed from the top of the <see cref="ArrayBasedStack{T}"/>.</returns>
         public T Pop()
         {
-            var item = stack[^1];
-            Array.Resize(ref stack, stack.Length - 1);
+            var item = stack[count - 1];
+            count = count - 1;
             return item;
         }
 
@@ -79,8 +102,13 @@ namespace DataStructures.ArrayBasedStack
         /// <param name="item">The item to push onto the <see cref="ArrayBasedStack{T}"/>.</param>
         public void Push(T item)
         {
-            Array.Resize(ref stack, stack.Length + 1);
-            stack[^1] = item;
+            if (count == Capacity)
+            {
+                Capacity = Capacity * 2;
+            }
+
+            stack[count] = item;
+            count = count + 1;
         }
     }
 }


### PR DESCRIPTION
Please include a summary of the change. Please also include relevant motivation and context (if applicable).

- [x] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have added comments to hard-to-understand areas of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have made corresponding changes to the comments
- [ ] I have made corresponding changes to the README.md

As discussed in [here](https://github.com/TheAlgorithms/C-Sharp/pull/137#pullrequestreview-360866552) change the `ArrayBaseStack.cs` to not resizes on every PUSH so that it can be `O(1)`. The stack has now a Capacity which will double if it runs out of space. 
