### PR TITLE
Fix link for `A-Star` in `DIRECTORY.md`

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -35,7 +35,7 @@
   * [Perfect Square Checker](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Numeric/PerfectSquareChecker.cs)
   * [Euler Method](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Numeric/EulerMethod.cs)
 ## Searches
-  * [A-Star](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/AStar/)
+  * [A-Star](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/AStar/AStar.cs)
   * [Binary Search](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/BinarySearcher.cs)
   * [Recursive Binary Search](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/RecursiveBinarySearcher.cs)
   * [Linear Search](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/LinearSearcher.cs)


### PR DESCRIPTION
The link was 
`https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/AStar`
and now is
`https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Search/AStar/AStar.cs`

This is only temporary and I know it is not really optimal because the algorithm is split into multiple files, but the website currently only works with a single file. The issue also occurs with other algorithms. Would it be possible to put everything important from one algorithm in one file @siriak or should I try to find another solution?