### PR TITLE
Fix stale messages

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
           exempt-issue-labels: 'dont-close'
           exempt-pr-labels: 'dont-close'


### PR DESCRIPTION
Fix stale messages so that they show the real timeframe for generating some activity that prevents an issue/pr from being closed (that is, `5 days -> 7 days`).

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code
- [x] I have made corresponding changes to the README.md
