### PR TITLE
Remove uses of ApplicationException

### DIFF
--- a/Algorithms/Search/AStar/PathfindingException.cs
+++ b/Algorithms/Search/AStar/PathfindingException.cs
@@ -5,7 +5,7 @@ namespace Algorithms.Search.AStar
     /// <summary>
     ///     A pathfinding exception is thrown when the Pathfinder encounters a critical error and can not continue.
     /// </summary>
-    public class PathfindingException : ApplicationException
+    public class PathfindingException : Exception
     {
         public PathfindingException(string message)
             : base(message)

--- a/Utilities/Exceptions/ItemNotFoundException.cs
+++ b/Utilities/Exceptions/ItemNotFoundException.cs
@@ -5,7 +5,7 @@ namespace Utilities.Exceptions
     /// <summary>
     ///     Signs that sequence doesn't contain any items that one was looking for.
     /// </summary>
-    public class ItemNotFoundException : ApplicationException
+    public class ItemNotFoundException : Exception
     {
     }
 }


### PR DESCRIPTION
This PR replaces two uses of the `ApplicationException` class as a base class, using the `Exception` class instead.

This may seem tangential, but as this repository serves as a learning resource, I do believe that it should follow the best practices.

Using `ApplicationException` is not recommended. The [official documentation](https://learn.microsoft.com/en-us/dotnet/api/system.applicationexception?view=net-6.0) includes this remark:

> You should derive custom exceptions from the [Exception](https://learn.microsoft.com/en-us/dotnet/api/system.exception?view=net-6.0) class rather than the [ApplicationException](https://learn.microsoft.com/en-us/dotnet/api/system.applicationexception?view=net-6.0) class. You should not throw an [ApplicationException](https://learn.microsoft.com/en-us/dotnet/api/system.applicationexception?view=net-6.0) exception in your code, and you should not catch an [ApplicationException](https://learn.microsoft.com/en-us/dotnet/api/system.applicationexception?view=net-6.0) exception unless you intend to re-throw the original exception.