### PR TITLE
Add Hamming distance

### DIFF
--- a/Algorithms.Tests/Strings/HammingDistanceTests.cs
+++ b/Algorithms.Tests/Strings/HammingDistanceTests.cs
@@ -1,0 +1,25 @@
+using Algorithms.Strings;
+using NUnit.Framework;
+using System;
+
+namespace Algorithms.Tests.Strings
+{
+    public class HammingDistanceTests
+    {
+        [Test]
+        [TestCase("equal", "equal", 0)]
+        [TestCase("dog", "dig", 1)]
+        [TestCase("12345", "abcde", 5)]
+        public void Calculate_ReturnsCorrectHammingDistance(string s1, string s2, int expectedDistance)
+        {
+            var result = HammingDistance.Calculate(s1, s2);
+            Assert.AreEqual(expectedDistance, result);
+        }
+
+        [Test]
+        public void Calculate_ThrowsArgumentExceptionWhenStringLengthsDiffer()
+        {
+            Assert.Throws<ArgumentException>(() => HammingDistance.Calculate("123", "12345"));
+        }
+    }
+}

--- a/Algorithms/Strings/HammingDistance.cs
+++ b/Algorithms/Strings/HammingDistance.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Algorithms.Strings
+{
+    /// <summary>
+    ///     <para>
+    ///         Hamming distance between two strings of equal length is the number of positions at which the corresponding symbols are different.
+    ///         Time complexity is O(n) where n is the length of the string.
+    ///     </para>
+    ///     <para>
+    ///         Wikipedia: https://en.wikipedia.org/wiki/Hamming_distance.
+    ///     </para>
+    /// </summary>
+    public static class HammingDistance
+    {
+        /// <summary>
+        ///     Calculates Hamming distance between two strings of equal length.
+        /// </summary>
+        /// <param name="s1">First string.</param>
+        /// <param name="s2">Second string.</param>
+        /// <returns>Levenshtein distance between source and target strings.</returns>
+        public static int Calculate(string s1, string s2)
+        {
+            if(s1.Length != s2.Length)
+            {
+                throw new ArgumentException("Strings must be equal length.");
+            }
+
+            var distance = 0;
+            for (var i = 0; i < s1.Length; i++)
+            {
+                distance += s1[i] != s2[i] ? 1 : 0;
+            }
+
+            return distance;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This repository contains algorithms and data structures implemented in C# for ed
     * [Boyer Moore](./Algorithms/Strings/BoyerMoore.cs)
     * [Palindrome Checker](./Algorithms/Strings/Palindrome.cs)
     * [Get all permutations of a string](./Algorithms/Strings/Permutation.cs)
+    * [Hamming Distance](./Algorithms/Strings/HammingDistance.cs)
   * [Other](./Algorithms/Other)
     * [Fermat Prime Checker](./Algorithms/Other/FermatPrimeChecker.cs)
     * [Sieve of Eratosthenes](./Algorithms/Other/SieveOfEratosthenes.cs)


### PR DESCRIPTION
Hamming distance between two [strings](https://en.wikipedia.org/wiki/String_(computer_science)) of equal length is the number of positions at which the corresponding [symbols](https://en.wikipedia.org/wiki/Symbol) are different. In other words, it measures the minimum number of substitutions required to change one string into the other, or the minimum number of errors that could have transformed one string into the other.

Wikipedia: https://en.wikipedia.org/wiki/Hamming_distance

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code
- [x] I have made corresponding changes to the README.md
