### PR TITLE
New OEIS sequences: A000124, A000125, A000213, A000288

### DIFF
--- a/Algorithms.Tests/Sequences/CakeNumbersSequenceTests.cs
+++ b/Algorithms.Tests/Sequences/CakeNumbersSequenceTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Numerics;
+using Algorithms.Sequences;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Sequences;
+
+public class CakeNumbersSequenceTests
+{
+    [Test]
+    public void First46ElementsCorrect()
+    {
+        var sequence = new CakeNumbersSequence().Sequence.Take(46);
+        sequence.SequenceEqual(new BigInteger[]
+            {
+                1, 2, 4, 8, 15, 26, 42, 64, 93, 130,
+                176, 232, 299, 378, 470, 576, 697, 834, 988, 1160,
+                1351, 1562, 1794, 2048, 2325, 2626, 2952, 3304, 3683, 4090,
+                4526, 4992, 5489, 6018, 6580, 7176, 7807, 8474, 9178, 9920,
+                10701, 11522, 12384, 13288, 14235, 15226
+            })
+            .Should().BeTrue();
+    }
+}

--- a/Algorithms.Tests/Sequences/CentralPolygonalNumbersSequenceTests.cs
+++ b/Algorithms.Tests/Sequences/CentralPolygonalNumbersSequenceTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Numerics;
+using Algorithms.Sequences;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Sequences;
+
+public class CentralPolygonalNumbersSequenceTests
+{
+    [Test]
+    public void First53ElementsCorrect()
+    {
+        var sequence = new CentralPolygonalNumbersSequence().Sequence.Take(53);
+        sequence.SequenceEqual(new BigInteger[]
+            {
+                1, 2, 4, 7, 11, 16, 22, 29, 37, 46, 56, 67, 79, 92, 106, 121, 137, 154, 172, 191, 211, 232, 254,
+                277, 301, 326, 352, 379, 407, 436, 466, 497, 529, 562, 596, 631, 667, 704, 742, 781, 821, 862, 904,
+                947, 991, 1036, 1082, 1129, 1177, 1226, 1276, 1327, 1379,
+            })
+            .Should().BeTrue();
+    }
+}

--- a/Algorithms.Tests/Sequences/TetranacciNumbersSequenceTests.cs
+++ b/Algorithms.Tests/Sequences/TetranacciNumbersSequenceTests.cs
@@ -9,7 +9,7 @@ namespace Algorithms.Tests.Sequences;
 public class TetranacciNumbersSequenceTests
 {
     [Test]
-    public void First34ElementsCorrect()
+    public void First35ElementsCorrect()
     {
         var sequence = new TetranacciNumbersSequence().Sequence.Take(35);
         sequence.SequenceEqual(new BigInteger[]

--- a/Algorithms.Tests/Sequences/TetranacciNumbersSequenceTests.cs
+++ b/Algorithms.Tests/Sequences/TetranacciNumbersSequenceTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Numerics;
+using Algorithms.Sequences;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Sequences;
+
+public class TetranacciNumbersSequenceTests
+{
+    [Test]
+    public void First34ElementsCorrect()
+    {
+        var sequence = new TetranacciNumbersSequence().Sequence.Take(35);
+        sequence.SequenceEqual(new BigInteger[]
+            {
+                1, 1, 1, 1, 4, 7, 13, 25, 49, 94, 181, 349, 673, 1297, 2500, 4819, 9289, 17905, 34513, 66526, 128233,
+                247177, 476449, 918385, 1770244, 3412255, 6577333, 12678217, 24438049, 47105854, 90799453, 175021573,
+                337364929, 650291809, 1253477764,
+            })
+            .Should().BeTrue();
+    }
+}

--- a/Algorithms.Tests/Sequences/TribonacciNumbersSequenceTests.cs
+++ b/Algorithms.Tests/Sequences/TribonacciNumbersSequenceTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Numerics;
+using Algorithms.Sequences;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Sequences;
+
+public class TribonacciNumbersSequenceTests
+{
+    [Test]
+    public void First37ElementsCorrect()
+    {
+        var sequence = new TribonacciNumbersSequence().Sequence.Take(37);
+        sequence.SequenceEqual(new BigInteger[]
+            {
+                1, 1, 1, 3, 5, 9, 17, 31, 57, 105, 193, 355, 653, 1201, 2209, 4063, 7473, 13745, 25281, 46499, 85525,
+                157305, 289329, 532159, 978793, 1800281, 3311233, 6090307, 11201821, 20603361, 37895489, 69700671,
+                128199521, 235795681, 433695873, 797691075, 1467182629,
+            })
+            .Should().BeTrue();
+    }
+}

--- a/Algorithms/Sequences/CakeNumbersSequence.cs
+++ b/Algorithms/Sequences/CakeNumbersSequence.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Cake numbers: maximal number of pieces resulting from n planar cuts through a cube
+///         (or cake): C(n+1,3) + n + 1.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000125.
+///     </para>
+/// </summary>
+public class CakeNumbersSequence : ISequence
+{
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            var n = new BigInteger(0);
+            while (true)
+            {
+                var next = (BigInteger.Pow(n, 3) + 5 * n + 6) / 6;
+                n++;
+                yield return next;
+            }
+        }
+    }
+}

--- a/Algorithms/Sequences/CentralPolygonalNumbersSequence.cs
+++ b/Algorithms/Sequences/CentralPolygonalNumbersSequence.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Central polygonal numbers (the Lazy Caterer's sequence): n(n+1)/2 + 1; or, maximal number of pieces
+///         formed when slicing a pancake with n cuts.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000124.
+///     </para>
+/// </summary>
+public class CentralPolygonalNumbersSequence : ISequence
+{
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            var n = new BigInteger(0);
+            while (true)
+            {
+                var next = n * (n + 1) / 2 + 1;
+                n++;
+                yield return next;
+            }
+        }
+    }
+}

--- a/Algorithms/Sequences/TetranacciNumbersSequence.cs
+++ b/Algorithms/Sequences/TetranacciNumbersSequence.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Tetranacci numbers: a(n) = a(n-1) + a(n-2) + a(n-3) + a(n-4) with a(0) = a(1) = a(2) = a(3) = 1.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000288.
+///     </para>
+/// </summary>
+public class TetranacciNumbersSequence : ISequence
+{
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            yield return 1;
+            yield return 1;
+            yield return 1;
+            yield return 1;
+
+            var buffer = new[] { new BigInteger(1), new BigInteger(1), new BigInteger(1), new BigInteger(1) };
+            while (true)
+            {
+                var next = buffer[0] + buffer[1] + buffer[2] + buffer[3];
+                buffer[0] = buffer[1];
+                buffer[1] = buffer[2];
+                buffer[2] = buffer[3];
+                buffer[3] = next;
+                yield return next;
+            }
+        }
+    }
+}

--- a/Algorithms/Sequences/TetranacciNumbersSequence.cs
+++ b/Algorithms/Sequences/TetranacciNumbersSequence.cs
@@ -17,20 +17,15 @@ public class TetranacciNumbersSequence : ISequence
     {
         get
         {
-            yield return 1;
-            yield return 1;
-            yield return 1;
-            yield return 1;
-
-            var buffer = new[] { new BigInteger(1), new BigInteger(1), new BigInteger(1), new BigInteger(1) };
+            var buffer = Enumerable.Repeat(BigInteger.One, 4).ToArray();
             while (true)
             {
+                yield return buffer[0];
                 var next = buffer[0] + buffer[1] + buffer[2] + buffer[3];
                 buffer[0] = buffer[1];
                 buffer[1] = buffer[2];
                 buffer[2] = buffer[3];
                 buffer[3] = next;
-                yield return next;
             }
         }
     }

--- a/Algorithms/Sequences/TetranacciNumbersSequence.cs
+++ b/Algorithms/Sequences/TetranacciNumbersSequence.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace Algorithms.Sequences;

--- a/Algorithms/Sequences/TribonacciNumbersSequence.cs
+++ b/Algorithms/Sequences/TribonacciNumbersSequence.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Tribonacci numbers: a(n) = a(n-1) + a(n-2) + a(n-3) with a(0)=a(1)=a(2)=1.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000213.
+///     </para>
+/// </summary>
+public class TribonacciNumbersSequence : ISequence
+{
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            yield return 1;
+            yield return 1;
+            yield return 1;
+            BigInteger beforePrevious = 1;
+            BigInteger previous = 1;
+            BigInteger current = 1;
+            while (true)
+            {
+                var next = beforePrevious + previous + current;
+                beforePrevious = previous;
+                previous = current;
+                current = next;
+                yield return next;
+            }
+        }
+    }
+}

--- a/Algorithms/Sequences/TribonacciNumbersSequence.cs
+++ b/Algorithms/Sequences/TribonacciNumbersSequence.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace Algorithms.Sequences;
@@ -17,19 +18,14 @@ public class TribonacciNumbersSequence : ISequence
     {
         get
         {
-            yield return 1;
-            yield return 1;
-            yield return 1;
-            BigInteger beforePrevious = 1;
-            BigInteger previous = 1;
-            BigInteger current = 1;
+            var buffer = Enumerable.Repeat(BigInteger.One, 4).ToArray();
             while (true)
             {
-                var next = beforePrevious + previous + current;
-                beforePrevious = previous;
-                previous = current;
-                current = next;
-                yield return next;
+                yield return buffer[0];
+                var next = buffer[0] + buffer[1] + buffer[2];
+                buffer[0] = buffer[1];
+                buffer[1] = buffer[2];
+                buffer[2] = next;
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ find more than one implementation for the same objective but using different alg
     * [A000124 Central Polygonal Numbers](./Algorithms/Sequences/CentralPolygonalNumbersSequence.cs)
     * [A000125 Cake Numbers](./Algorithms/Sequences/CakeNumbersSequence.cs)
     * [A000142 Factorial](./Algorithms/Sequences/FactorialSequence.cs)
+    * [A000213 Tribonacci Numbers](./Algorithms/Sequences/TribonacciNumbersSequence.cs)
     * [A000215 Fermat Numbers](./Algorithms/Sequences/FermatNumbersSequence.cs)
     * [A000290 Squares](./Algorithms/Sequences/SquaresSequence.cs)
     * [A000292 Tetrahedral numbers](./Algorithms/Sequences/TetrahedralSequence.cs)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ find more than one implementation for the same objective but using different alg
     * [A000142 Factorial](./Algorithms/Sequences/FactorialSequence.cs)
     * [A000213 Tribonacci Numbers](./Algorithms/Sequences/TribonacciNumbersSequence.cs)
     * [A000215 Fermat Numbers](./Algorithms/Sequences/FermatNumbersSequence.cs)
+    * [A000288 Tetranacci Numbers](./Algorithms/Sequences/TetranacciNumbersSequence.cs)
     * [A000290 Squares](./Algorithms/Sequences/SquaresSequence.cs)
     * [A000292 Tetrahedral numbers](./Algorithms/Sequences/TetrahedralSequence.cs)
     * [A000578 Cubes](./Algorithms/Sequences/CubesSequence.cs)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ find more than one implementation for the same objective but using different alg
     * [A000108 Catalan](./Algorithms/Sequences/CatalanSequence.cs)
     * [A000120 1's Counting](./Algorithms/Sequences/OnesCountingSequence.cs)
     * [A000124 Central Polygonal Numbers](./Algorithms/Sequences/CentralPolygonalNumbersSequence.cs)
+    * [A000125 Cake Numbers](./Algorithms/Sequences/CakeNumbersSequence.cs)
     * [A000142 Factorial](./Algorithms/Sequences/FactorialSequence.cs)
     * [A000215 Fermat Numbers](./Algorithms/Sequences/FermatNumbersSequence.cs)
     * [A000290 Squares](./Algorithms/Sequences/SquaresSequence.cs)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ find more than one implementation for the same objective but using different alg
     * [A000079 Powers of 2](./Algorithms/Sequences/PowersOf2Sequence.cs)
     * [A000108 Catalan](./Algorithms/Sequences/CatalanSequence.cs)
     * [A000120 1's Counting](./Algorithms/Sequences/OnesCountingSequence.cs)
+    * [A000124 Central Polygonal Numbers](./Algorithms/Sequences/CentralPolygonalNumbersSequence.cs)
     * [A000142 Factorial](./Algorithms/Sequences/FactorialSequence.cs)
     * [A000215 Fermat Numbers](./Algorithms/Sequences/FermatNumbersSequence.cs)
     * [A000290 Squares](./Algorithms/Sequences/SquaresSequence.cs)


### PR DESCRIPTION
Issue #222: Add the implementation of the following OEIS to the repository:

- A000124 - Central Polygonal Numbers
- A000125 - Cake Numbers
- A000213 - Tribonacci Numbers
- A000288 - Tetranacci Numbers

- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Comments in areas I changed are up to date
- [X] I have added comments to hard-to-understand areas of my code
- [X] I have made corresponding changes to the README.md
