### PR TITLE
(Fix IDE0180) Favor modern tuple swap over temporary variables.

### DIFF
--- a/Algorithms/Numeric/GreatestCommonDivisor/BinaryGreatestCommonDivisorFinder.cs
+++ b/Algorithms/Numeric/GreatestCommonDivisor/BinaryGreatestCommonDivisorFinder.cs
@@ -54,9 +54,7 @@ namespace Algorithms.Numeric.GreatestCommonDivisor
                 // Now u and v are both odd. Swap if necessary so u <= v,
                 if (u > v)
                 {
-                    var t = v;
-                    v = u;
-                    u = t;
+                    (u, v) = (v, u);
                 }
 
                 // Here v >= u and v - u is even

--- a/Algorithms/Sorters/Comparison/BubbleSorter.cs
+++ b/Algorithms/Sorters/Comparison/BubbleSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -26,9 +26,7 @@ namespace Algorithms.Sorters.Comparison
                 {
                     if (comparer.Compare(array[j], array[j + 1]) > 0)
                     {
-                        var temp = array[j];
-                        array[j] = array[j + 1];
-                        array[j + 1] = temp;
+                        (array[j + 1], array[j]) = (array[j], array[j + 1]);
                         wasChanged = true;
                     }
                 }

--- a/Algorithms/Sorters/Comparison/CocktailSorter.cs
+++ b/Algorithms/Sorters/Comparison/CocktailSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -32,9 +32,7 @@ namespace Algorithms.Sorters.Comparison
                         continue;
                     }
 
-                    var highValue = array[i];
-                    array[i] = array[i + 1];
-                    array[i + 1] = highValue;
+                    (array[i + 1], array[i]) = (array[i], array[i + 1]);
                 }
 
                 endIndex--;
@@ -47,10 +45,7 @@ namespace Algorithms.Sorters.Comparison
                         continue;
                     }
 
-                    var highValue = array[i];
-                    array[i] = array[i - 1];
-                    array[i - 1] = highValue;
-
+                    (array[i - 1], array[i]) = (array[i], array[i - 1]);
                     swapped = true;
                 }
 

--- a/Algorithms/Sorters/Comparison/CycleSorter.cs
+++ b/Algorithms/Sorters/Comparison/CycleSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -37,18 +37,13 @@ namespace Algorithms.Sorters.Comparison
 
             pos = SkipSameElements(array, pos, item, comparer);
 
-            var temp = array[pos];
-            array[pos] = item;
-            item = temp;
-
+            (item, array[pos]) = (array[pos], item);
             while (pos != startingIndex)
             {
                 pos = startingIndex + CountSmallerElements(array, startingIndex + 1, item, comparer);
                 pos = SkipSameElements(array, pos, item, comparer);
 
-                temp = array[pos];
-                array[pos] = item;
-                item = temp;
+                (array[pos], item) = (item, array[pos]);
             }
         }
 

--- a/Algorithms/Sorters/Comparison/HeapSorter.cs
+++ b/Algorithms/Sorters/Comparison/HeapSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -26,10 +26,7 @@ namespace Algorithms.Sorters.Comparison
 
             for (var i = data.Count - 1; i > 0; i--)
             {
-                var temp = data[i];
-                data[i] = data[0];
-                data[0] = temp;
-
+                (data[0], data[i]) = (data[i], data[0]);
                 heapSize--;
                 MakeHeap(data, heapSize, 0, comparer);
             }
@@ -57,10 +54,7 @@ namespace Algorithms.Sorters.Comparison
                 }
 
                 // process of reheaping / swapping
-                var temp = input[rIndex];
-                input[rIndex] = input[largest];
-                input[largest] = temp;
-
+                (input[largest], input[rIndex]) = (input[rIndex], input[largest]);
                 rIndex = largest;
             }
         }

--- a/Algorithms/Sorters/Comparison/InsertionSorter.cs
+++ b/Algorithms/Sorters/Comparison/InsertionSorter.cs
@@ -23,9 +23,7 @@ namespace Algorithms.Sorters.Comparison
             {
                 for (var j = i; j > 0 && comparer.Compare(array[j], array[j - 1]) < 0; j--)
                 {
-                    var temp = array[j - 1];
-                    array[j - 1] = array[j];
-                    array[j] = temp;
+                    (array[j], array[j - 1]) = (array[j - 1], array[j]);
                 }
             }
         }

--- a/Algorithms/Sorters/Comparison/QuickSorter.cs
+++ b/Algorithms/Sorters/Comparison/QuickSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -56,10 +56,7 @@ namespace Algorithms.Sorters.Comparison
                     return nright;
                 }
 
-                var t = array[nleft];
-                array[nleft] = array[nright];
-                array[nright] = t;
-
+                (array[nright], array[nleft]) = (array[nleft], array[nright]);
                 nleft++;
                 nright--;
             }

--- a/Algorithms/Sorters/Comparison/SelectionSorter.cs
+++ b/Algorithms/Sorters/Comparison/SelectionSorter.cs
@@ -30,9 +30,7 @@ namespace Algorithms.Sorters.Comparison
                     }
                 }
 
-                var t = array[i];
-                array[i] = array[jmin];
-                array[jmin] = t;
+                (array[jmin], array[i]) = (array[i], array[jmin]);
             }
         }
     }

--- a/Algorithms/Sorters/Comparison/ShellSorter.cs
+++ b/Algorithms/Sorters/Comparison/ShellSorter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Algorithms.Sorters.Comparison
 {
@@ -38,9 +38,7 @@ namespace Algorithms.Sorters.Comparison
                 {
                     if (comparer.Compare(array[k], array[k + step]) > 0)
                     {
-                        var temp = array[k];
-                        array[k] = array[k + step];
-                        array[k + step] = temp;
+                        (array[k + step], array[k]) = (array[k], array[k + step]);
                         wasChanged = true;
                     }
                 }

--- a/Algorithms/Sorters/Integer/RadixSorter.cs
+++ b/Algorithms/Sorters/Integer/RadixSorter.cs
@@ -1,4 +1,4 @@
-﻿namespace Algorithms.Sorters.Integer
+namespace Algorithms.Sorters.Integer
 {
     /// <summary>
     ///     Radix sort is a non-comparative integer sorting algorithm that sorts data with integer keys by grouping keys by the
@@ -40,9 +40,7 @@
                     b[cntarray[key]] = array[p];
                 }
 
-                var temp = b;
-                b = array;
-                array = temp;
+                (array, b) = (b, array);
             }
         }
     }

--- a/DataStructures/Heap/BinaryHeap.cs
+++ b/DataStructures/Heap/BinaryHeap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace DataStructures.Heap
@@ -181,9 +181,7 @@ namespace DataStructures.Heap
         /// <param name="idx2">Second index.</param>
         private void Swap(int idx1, int idx2)
         {
-            var tmp = data[idx1];
-            data[idx1] = data[idx2];
-            data[idx2] = tmp;
+            (data[idx2], data[idx1]) = (data[idx1], data[idx2]);
         }
 
         /// <summary>

--- a/DataStructures/Heap/FibonacciHeap/FibonacciHeap.cs
+++ b/DataStructures/Heap/FibonacciHeap/FibonacciHeap.cs
@@ -363,9 +363,7 @@ namespace DataStructures.Heap.FibonacciHeap
                     if (x.Key.CompareTo(y.Key) > 0)
                     {
                         // Exchange x and y
-                        var temp = x;
-                        x = y;
-                        y = temp;
+                        (y, x) = (x, y);
                     }
 
                     // Make y a child of x

--- a/DataStructures/Heap/MinMaxHeap.cs
+++ b/DataStructures/Heap/MinMaxHeap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -373,9 +373,7 @@ namespace DataStructures.Heap
 
         private void SwapNodes(int i, int j)
         {
-            var temp = heap[i];
-            heap[i] = heap[j];
-            heap[j] = temp;
+            (heap[j], heap[i]) = (heap[i], heap[j]);
         }
     }
 }


### PR DESCRIPTION
<!--
Please include a summary of the change.
Please also include relevant motivation and context (if applicable).
Put 'x' in between square brackets to mark an item as complete.
[x] means checked checkbox
[ ] means unchecked checkbox
-->

C# 7 brought tuple types, which allowed for very clean and efficient swapping of values. This pull request replaces temporary variable assignments across the repository with said feature:
```csharp
// === Example ===
// before:
int temp = numbers[0];
numbers[0] = numbers[1];
numbers[1] = temp;
// after
(numbers[1], numbers[0]) = (numbers[0], numbers[1]);
```
See more details on the code issue [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0180).

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works *(no new features)*
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code *(my changes makes stuff more understandable)*
- [x] I have made corresponding changes to the README.md *(nothing new)*
