### PR TITLE
Feature/pkcs7 padding

### DIFF
--- a/Algorithms.Tests/Crypto/Padding/PKCS7PaddingTests.cs
+++ b/Algorithms.Tests/Crypto/Padding/PKCS7PaddingTests.cs
@@ -14,7 +14,7 @@ public class PKCS7PaddingTests
     {
         const int blockSize = 0;
 
-        Action act = () => new PKCS7Padding(blockSize);
+        Action act = () => new Pkcs7Padding(blockSize);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
             .WithMessage("Invalid block size: 0 (Parameter 'blockSize')");
@@ -25,7 +25,7 @@ public class PKCS7PaddingTests
     {
         const int blockSize = 256;
 
-        Action act = () => new PKCS7Padding(blockSize);
+        Action act = () => new Pkcs7Padding(blockSize);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
             .WithMessage("Invalid block size: 256 (Parameter 'blockSize')");
@@ -36,7 +36,7 @@ public class PKCS7PaddingTests
     {
         const int blockSize = 128;
 
-        Action act = () => new PKCS7Padding(blockSize);
+        Action act = () => new Pkcs7Padding(blockSize);
 
         act.Should().NotThrow();
     }
@@ -44,7 +44,7 @@ public class PKCS7PaddingTests
     [Test]
     public void AddPadding_WhenNotEnoughSpaceInInputArrayForPadding_ShouldThrowArgumentException()
     {
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
         const int inputOffset = 1;
 
         var size16Input = new byte[16];
@@ -58,7 +58,7 @@ public class PKCS7PaddingTests
     [Test]
     public void AddPadding_WhenInputArrayHasEnoughSpace_ShouldReturnCorrectPaddingSize()
     {
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
         const int inputOffset = defaultBlockSize;
 
         var size32Input = new byte[32];
@@ -71,12 +71,12 @@ public class PKCS7PaddingTests
     [Test]
     public void AddPadding_WhenAppliedToAnInputArray_ShouldAddCorrectPKCS7Padding()
     {
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
         const int inputOffset = defaultBlockSize;
 
         var size32Input = new byte[32];
 
-        var result = padding.AddPadding(size32Input, inputOffset);
+        padding.AddPadding(size32Input, inputOffset);
 
         for (var i = 0; i < defaultBlockSize - 1; i++)
         {
@@ -94,7 +94,7 @@ public class PKCS7PaddingTests
             size32Input[size32Input.Length - 1 - i] = (byte)paddingSize;
         }
 
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         var output = padding.RemovePadding(size32Input);
 
@@ -105,7 +105,7 @@ public class PKCS7PaddingTests
     public void RemovePadding_WhenInputLengthNotMultipleOfBlockSize_ShouldThrowArgumentException()
     {
         var input = new byte[defaultBlockSize + 1]; // Length is not a multiple of blockSize
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         Action act = () => padding.RemovePadding(input);
 
@@ -119,7 +119,7 @@ public class PKCS7PaddingTests
         var size32Input = new byte[32];
 
         size32Input[^1] = (byte)(defaultBlockSize + 1); // Set invalid padding length
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         Action act = () => padding.RemovePadding(size32Input);
 
@@ -133,7 +133,7 @@ public class PKCS7PaddingTests
 
         size32Input[^1] = (byte)(defaultBlockSize); // Set valid padding length
         size32Input[^2] = (byte)(defaultBlockSize - 1); // Set invalid padding byte
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         Action act = () => padding.RemovePadding(size32Input);
 
@@ -152,7 +152,7 @@ public class PKCS7PaddingTests
             size32Input[size32Input.Length - 1 - i] = (byte)paddingSize; // Add padding bytes at the end of the array
         }
 
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         var output = padding.GetPaddingCount(size32Input);
 
@@ -167,7 +167,7 @@ public class PKCS7PaddingTests
         size32Input[^1] = defaultBlockSize;
         size32Input[^2] = defaultBlockSize - 1;
 
-        var padding = new PKCS7Padding(defaultBlockSize);
+        var padding = new Pkcs7Padding(defaultBlockSize);
 
         Action act = () => padding.GetPaddingCount(size32Input);
 

--- a/Algorithms.Tests/Crypto/Padding/PKCS7PaddingTests.cs
+++ b/Algorithms.Tests/Crypto/Padding/PKCS7PaddingTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using Algorithms.Crypto.Paddings;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Crypto.Padding;
+
+public class PKCS7PaddingTests
+{
+    private const int defaultBlockSize = 16;
+
+    [Test]
+    public void Constructor_WhenBlockSizeIsLessThanOne_ShouldThrowArgumentOutOfRangeException()
+    {
+        const int blockSize = 0;
+
+        Action act = () => new PKCS7Padding(blockSize);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Invalid block size: 0 (Parameter 'blockSize')");
+    }
+
+    [Test]
+    public void Constructor_WhenBlockSizeIsMoreThan255_ShouldThrowArgumentOutOfRangeException()
+    {
+        const int blockSize = 256;
+
+        Action act = () => new PKCS7Padding(blockSize);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("Invalid block size: 256 (Parameter 'blockSize')");
+    }
+
+    [Test]
+    public void Constructor_WhenBlockSizeIsWithinValidRange_ShouldNotThrowAFit()
+    {
+        const int blockSize = 128;
+
+        Action act = () => new PKCS7Padding(blockSize);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void AddPadding_WhenNotEnoughSpaceInInputArrayForPadding_ShouldThrowArgumentException()
+    {
+        var padding = new PKCS7Padding(defaultBlockSize);
+        const int inputOffset = 1;
+
+        var size16Input = new byte[16];
+
+        Action act = () => padding.AddPadding(size16Input, inputOffset);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Not enough space in input array for padding");
+    }
+
+    [Test]
+    public void AddPadding_WhenInputArrayHasEnoughSpace_ShouldReturnCorrectPaddingSize()
+    {
+        var padding = new PKCS7Padding(defaultBlockSize);
+        const int inputOffset = defaultBlockSize;
+
+        var size32Input = new byte[32];
+
+        var result = padding.AddPadding(size32Input, inputOffset);
+
+        result.Should().Be(defaultBlockSize);
+    }
+
+    [Test]
+    public void AddPadding_WhenAppliedToAnInputArray_ShouldAddCorrectPKCS7Padding()
+    {
+        var padding = new PKCS7Padding(defaultBlockSize);
+        const int inputOffset = defaultBlockSize;
+
+        var size32Input = new byte[32];
+
+        var result = padding.AddPadding(size32Input, inputOffset);
+
+        for (var i = 0; i < defaultBlockSize - 1; i++)
+        {
+            size32Input[inputOffset + i].Should().Be(defaultBlockSize);
+        }
+    }
+
+    [Test]
+    public void RemovePadding_WhenAppliedToAValidInputArray_ShouldRemovePKCS7PaddingCorrectly()
+    {
+        var paddingSize = 5;
+        var size32Input = new byte[32];
+        for (var i = 0; i < paddingSize; i++)
+        {
+            size32Input[size32Input.Length - 1 - i] = (byte)paddingSize;
+        }
+
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        var output = padding.RemovePadding(size32Input);
+
+        output.Length.Should().Be(size32Input.Length - paddingSize);
+    }
+
+    [Test]
+    public void RemovePadding_WhenInputLengthNotMultipleOfBlockSize_ShouldThrowArgumentException()
+    {
+        var input = new byte[defaultBlockSize + 1]; // Length is not a multiple of blockSize
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        Action act = () => padding.RemovePadding(input);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Input length must be a multiple of block size");
+    }
+
+    [Test]
+    public void RemovePadding_WhenInvalidPaddingLength_ShouldThrowArgumentException()
+    {
+        var size32Input = new byte[32];
+
+        size32Input[^1] = (byte)(defaultBlockSize + 1); // Set invalid padding length
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        Action act = () => padding.RemovePadding(size32Input);
+
+        act.Should().Throw<ArgumentException>().WithMessage("Invalid padding length");
+    }
+
+    [Test]
+    public void RemovePadding_WhenInvalidPadding_ShouldThrowArgumentException()
+    {
+        var size32Input = new byte[32];
+
+        size32Input[^1] = (byte)(defaultBlockSize); // Set valid padding length
+        size32Input[^2] = (byte)(defaultBlockSize - 1); // Set invalid padding byte
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        Action act = () => padding.RemovePadding(size32Input);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Invalid padding");
+    }
+
+    [Test]
+    public void GetPaddingCount_WhenInputArrayIsValid_ShouldReturnCorrectPaddingCount()
+    {
+        var paddingSize = 5;
+        var size32Input = new byte[32];
+
+        for (var i = 0; i < paddingSize; i++)
+        {
+            size32Input[size32Input.Length - 1 - i] = (byte)paddingSize; // Add padding bytes at the end of the array
+        }
+
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        var output = padding.GetPaddingCount(size32Input);
+
+        output.Should().Be(paddingSize);
+    }
+
+    [Test]
+    public void GetPaddingCount_WhenInvalidPadding_ShouldThrowArgumentException()
+    {
+        var size32Input = new byte[32];
+
+        size32Input[^1] = defaultBlockSize;
+        size32Input[^2] = defaultBlockSize - 1;
+
+        var padding = new PKCS7Padding(defaultBlockSize);
+
+        Action act = () => padding.GetPaddingCount(size32Input);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Padding block is corrupted");
+    }
+}

--- a/Algorithms/Crypto/Paddings/PKCS7Padding.cs
+++ b/Algorithms/Crypto/Paddings/PKCS7Padding.cs
@@ -1,0 +1,177 @@
+﻿using System;
+
+namespace Algorithms.Crypto.Paddings;
+
+/// <summary>
+/// <para>
+/// This class implements the PKCS7 padding scheme, which is a standard way of padding data to fit a certain block size.
+/// </para>
+/// <para>
+/// PKCS7 padding adds N bytes of value N to the end of the data, where N is the number of bytes needed to reach the block size.
+/// For example, if the block size is 16 bytes, and the data is 11 bytes long, then 5 bytes of value 5 will be added to the
+/// end of the data. This way, the padded data will be 16 bytes long and can be encrypted or decrypted by a block cipher algorithm.
+/// </para>
+/// <para>
+/// The padding can be easily removed after decryption by looking at the last byte and subtracting that many bytes from the
+/// end of the data.
+/// </para>
+/// <para>
+/// This class supports any block size from 1 to 255 bytes, and can be used with any encryption algorithm that requires
+/// padding, such as AES.
+/// </para>
+/// </summary>
+public class PKCS7Padding
+{
+    private int blockSize;
+
+    public PKCS7Padding(int blockSize)
+    {
+        if (blockSize is < 1 or > 255)
+        {
+            throw new ArgumentOutOfRangeException(nameof(blockSize), $"Invalid block size: {blockSize}");
+        }
+
+        this.blockSize = blockSize;
+    }
+
+    /// <summary>
+    /// Adds padding to the end of a byte array according to the PKCS#7 standard.
+    /// </summary>
+    /// <param name="input">The byte array to be padded.</param>
+    /// <param name="inputOffset">The offset from which to start padding.</param>
+    /// <returns>The padding value that was added to each byte.</returns>
+    /// <exception cref="ArgumentException">
+    /// If the input array does not have enough space to add <c>blockSize</c> bytes as padding.
+    /// </exception>
+    /// <remarks>
+    /// The padding value is equal to the number of of bytes that are added to the array.
+    /// For example, if the input array has a length of 16 and the input offset is 10,
+    /// then 6 bytes with the value 6 will be added to the end of the array.
+    /// </remarks>
+    public int AddPadding(byte[] input, int inputOffset)
+    {
+        // Calculate how many bytes need to be added to reach the next multiple of block size.
+        var code = (byte)((blockSize - (input.Length % blockSize)) % blockSize);
+
+        // If no padding is needed, add a full block of padding.
+        if (code == 0)
+        {
+            code = (byte)blockSize;
+        }
+
+        if (inputOffset + code > input.Length)
+        {
+            throw new ArgumentException("Not enough space in input array for padding");
+        }
+
+        // Add the padding
+        for (var i = 0; i < code; i++)
+        {
+            input[inputOffset + i] = code;
+        }
+
+        return code;
+    }
+
+    /// <summary>
+    /// Removes the PKCS7 padding from the given input data.
+    /// </summary>
+    /// <param name="input">The input data with PKCS7 padding. Must not be null and must have a vaild length and padding.</param>
+    /// <returns>The input data without the padding as a new byte array.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the input data is null, has an invalid length, or has an invalid padding.
+    /// </exception>
+    public byte[] RemovePadding(byte[] input)
+    {
+        // Check if input length is a multiple of blockSize
+        if (input.Length % blockSize != 0)
+        {
+            throw new ArgumentException("Input length must be a multiple of block size");
+        }
+
+        // Get the padding length from the last byte of input
+        var paddingLength = input[^1];
+
+        // Check if padding length is valid
+        if (paddingLength < 1 || paddingLength > blockSize)
+        {
+            throw new ArgumentException("Invalid padding length");
+        }
+
+        // Check if all padding bytes have the correct value
+        for (var i = 0; i < paddingLength; i++)
+        {
+            if (input[input.Length - 1 - i] != paddingLength)
+            {
+                throw new ArgumentException("Invalid padding");
+            }
+        }
+
+        // Create a new array with the size of input minus the padding length
+        var output = new byte[input.Length - paddingLength];
+
+        // Copy the data without the padding into the output array
+        Array.Copy(input, output, output.Length);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Gets the number of padding bytes in the given input data according to the PKCS7 padding scheme.
+    /// </summary>
+    /// <param name="input">The input data with PKCS7 padding. Must not be null and must have a valid padding.</param>
+    /// <returns>The number of padding bytes in the input data.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the input data is null or has an invalid padding.
+    /// </exception>
+    /// <remarks>
+    /// This method uses bitwise operations to avoid branching.
+    /// </remarks>
+    public int GetPaddingCount(byte[] input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input), "Input cannot be null");
+        }
+
+        // Get the last byte of the input data as the padding value.
+        var lastByte = input[input.Length];
+        var paddingCount = lastByte & 0xFF;
+
+        // Calculate the index where the padding starts
+        var paddingStartIndex = input.Length - paddingCount;
+        var paddingCheckFailed = 0;
+
+        // Check if the padding start index is negative or greater than the input length.
+        // This is done by using bitwise operations to avoid branching.
+        // If the padding start index is negative, then its most significant bit will be 1.
+        // If the padding count is greater than the block size, then its most significant bit will be 1.
+        // By ORing these two cases, we can get a non-zero value rif either of them is true.
+        // By shifting this value right by 31 bits, we can get either 0 or -1 as the result.
+        paddingCheckFailed = (paddingStartIndex | (paddingCount - 1)) >> 31;
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            // Check if each byte matches the padding value.
+            // This is done by using bitwise operations to avoid branching.
+            // If a byte does not match the padding value, then XORing them will give a non-zero value.
+            // If a byte is before the padding start index, then we want to ignore it.
+            // This is done by using bitwise operations to create a mask that is either all zeros or all ones.
+            // If i is less than the padding start index, then subtracting them will give a negative value.
+            // By shifting this value right by 31 bits, we can get either -1 or 0 as the mask.
+            // By negating this mask, we can get either 0 or -1 as the mask.
+            // By ANDing this mask with the XOR result, we can get either 0 or the XOR result as the final result.
+            // By ORing this final result with the previous padding check result, we can accumulate any non-zero values.
+            paddingCheckFailed |= (input[i] ^ lastByte) & ~((i - paddingStartIndex) >> 31);
+        }
+
+        // Check if the padding check failed.
+        if (paddingCheckFailed != 0)
+        {
+            throw new ArgumentException("Padding block is corrupted");
+        }
+
+        // Return the number of padding bytes.
+        return paddingCount;
+    }
+}

--- a/Algorithms/Crypto/Paddings/PKCS7Padding.cs
+++ b/Algorithms/Crypto/Paddings/PKCS7Padding.cs
@@ -135,7 +135,7 @@ public class PKCS7Padding
         }
 
         // Get the last byte of the input data as the padding value.
-        var lastByte = input[input.Length];
+        var lastByte = input[^1];
         var paddingCount = lastByte & 0xFF;
 
         // Calculate the index where the padding starts

--- a/Algorithms/Crypto/Paddings/PKCS7Padding.cs
+++ b/Algorithms/Crypto/Paddings/PKCS7Padding.cs
@@ -20,11 +20,11 @@ namespace Algorithms.Crypto.Paddings;
 /// padding, such as AES.
 /// </para>
 /// </summary>
-public class PKCS7Padding
+public class Pkcs7Padding
 {
-    private int blockSize;
+    private readonly int blockSize;
 
-    public PKCS7Padding(int blockSize)
+    public Pkcs7Padding(int blockSize)
     {
         if (blockSize is < 1 or > 255)
         {

--- a/Algorithms/DataCompression/Translator.cs
+++ b/Algorithms/DataCompression/Translator.cs
@@ -4,16 +4,16 @@ using System.Text;
 namespace Algorithms.DataCompression
 {
     /// <summary>
-    ///     TODO.
+    ///     Provides method for text conversion by key mapping.
     /// </summary>
     public class Translator
     {
         /// <summary>
-        ///     TODO.
+        ///     Converts the input text according to the translation keys.
         /// </summary>
-        /// <param name="text">TODO. 2.</param>
-        /// <param name="translationKeys">TODO. 3.</param>
-        /// <returns>TODO. 4.</returns>
+        /// <param name="text">Input text.</param>
+        /// <param name="translationKeys">Translation keys used for text matching.</param>
+        /// <returns>Converted text according to the translation keys.</returns>
         public string Translate(string text, Dictionary<string, string> translationKeys)
         {
             var sb = new StringBuilder();

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ find more than one implementation for the same objective but using different alg
 ## List of Algorithms
 
 * [Algorithms](./Algorithms)
+  * [Crypto](./Algorithms/Crypto/)
+    * [Paddings](./Algorithms/Crypto/Paddings/)
+      * [PKC7 Padding](./Algorithms/Crypto/Paddings/PKCS7Padding.cs) 
   * [Data Compression](./Algorithms/DataCompression)
     * [Burrows-Wheeler transform](./Algorithms/DataCompression/BurrowsWheelerTransform.cs)
     * [Huffman Compressor](./Algorithms/DataCompression/HuffmanCompressor.cs)


### PR DESCRIPTION
<!--
Please include a summary of the change.
Please also include relevant motivation and context (if applicable).
Put 'x' in between square brackets to mark an item as complete.
[x] means checked checkbox
[ ] means unchecked checkbox
-->
This pull request introduces a new class that implements the PKCS7 padding algorithm. The class provides three main methods: `AddPadding`, `RemovePadding`, and `GetPaddingSize`.

- `AddPadding`: This method adds padding to the end of a byte array according to the PKCS#7 standard.
- `RemovePadding`: This method removes the PKCS7 padding from the given input data.
- `GetPaddingSize`: This method gets the number of padding bytes in the given input data according to the PKCS7 padding scheme.

The implementation uses bitwise operations to avoid branching, which can lead to more efficient code execution,and avoid timing attacks.

In addition, a new folder structure Crypto/Padding has been created for this implementation, as the current structure didn’t have any relevant folder for this implementation.

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code
- [x] I have made corresponding changes to the README.md
