### PR TITLE
Remove redundant attributes

### DIFF
--- a/Algorithms.Tests/Compressors/BurrowsWheelerTransformTests.cs
+++ b/Algorithms.Tests/Compressors/BurrowsWheelerTransformTests.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Compressors;
 
 public class BurrowsWheelerTransformTests
 {
-    [Test]
     [TestCase("banana", "nnbaaa", 3)]
     [TestCase("SIX.MIXED.PIXIES.SIFT.SIXTY.PIXIE.DUST.BOXES", "TEXYDST.E.IXIXIXXSSMPPS.B..E.S.EUSFXDIIOIIIT", 29)]
     [TestCase("", "", 0)]
@@ -20,7 +19,6 @@ public class BurrowsWheelerTransformTests
         Assert.AreEqual(expectedIndex, index);
     }
 
-    [Test]
     [TestCase("nnbaaa", 3, "banana")]
     [TestCase("TEXYDST.E.IXIXIXXSSMPPS.B..E.S.EUSFXDIIOIIIT", 29, "SIX.MIXED.PIXIES.SIFT.SIXTY.PIXIE.DUST.BOXES")]
     [TestCase("", 0, "")]

--- a/Algorithms.Tests/Compressors/HuffmanCompressorTests.cs
+++ b/Algorithms.Tests/Compressors/HuffmanCompressorTests.cs
@@ -8,7 +8,6 @@ namespace Algorithms.Tests.Compressors;
 
 public static class HuffmanCompressorTests
 {
-    [Test]
     [TestCase("This is a string", "101010110111011101110111100011111010010010010011000")]
     [TestCase("Hello", "1101110010")]
     [TestCase("dddddddddd", "1111111111")]

--- a/Algorithms.Tests/Compressors/ShannonFanoCompressorTests.cs
+++ b/Algorithms.Tests/Compressors/ShannonFanoCompressorTests.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Compressors;
 
 public static class ShannonFanoCompressorTests
 {
-    [Test]
     [TestCase("dddddddddd", "1111111111")]
     [TestCase("a", "1")]
     [TestCase("", "")]

--- a/Algorithms.Tests/Encoders/FeistelCipherTest.cs
+++ b/Algorithms.Tests/Encoders/FeistelCipherTest.cs
@@ -26,7 +26,6 @@ public static class FeistelCipherTests
         Assert.AreEqual(message, decoded);
     }
 
-    [Test]
     [TestCase("00001111",                           (uint)0x12345678)]
     [TestCase("00001111222233334444555566667",      (uint)0x12345678)]
     [TestCase("000011112222333344445555666677",     (uint)0x12345678)]

--- a/Algorithms.Tests/Graph/BreadthFirstTreeTraversalTests.cs
+++ b/Algorithms.Tests/Graph/BreadthFirstTreeTraversalTests.cs
@@ -39,7 +39,6 @@ public static class BreadthFirstTreeTraversalTests
         Assert.IsEmpty(levelOrder);
     }
 
-    [Test]
     [TestCase(new [] {7, 9, 5})]
     [TestCase(new [] { 7, 13, 11, 15, 14, 4, 5, 16, 2 })]
     public static void IncorrectLevelOrderTraversal(int[] insertion)

--- a/Algorithms.Tests/LinearAlgebra/Distances/EuclideanTests.cs
+++ b/Algorithms.Tests/LinearAlgebra/Distances/EuclideanTests.cs
@@ -8,12 +8,11 @@ namespace Algorithms.Tests.LinearAlgebra.Distances;
 public static class EuclideanTests
 {
     /// <summary>
-    /// Test the result given by Euclidean distance function. 
+    /// Test the result given by Euclidean distance function.
     /// </summary>
     /// <param name="point1">Origin point.</param>
     /// <param name="point2">Target point.</param>
     /// <param name="expectedResult">Expected result.</param>
-    [Test]
     [TestCase(new[] { 1.5 }, new[] { -1.0 }, 2.5)]
     [TestCase(new[] { 7.0, 4.0, 3.0 }, new[] { 17.0, 6.0, 2.0 }, 10.247)]
     public static void DistanceTest(double[] point1, double[] point2, double expectedResult)
@@ -26,7 +25,6 @@ public static class EuclideanTests
     /// </summary>
     /// <param name="point1">First point of N dimensions.</param>
     /// <param name="point2">Second point of M dimensions, M != N.</param>
-    [Test]
     [TestCase(new[] { 7.0, 4.5 }, new[] { -3.0 })]
     [TestCase(new[] { 12.0 }, new[] { 1.5, 7.0, 3.2 })]
     public static void DistanceThrowsArgumentExceptionOnDifferentPointDimensions(double[] point1, double[] point2)

--- a/Algorithms.Tests/LinearAlgebra/Distances/ManhattanTests.cs
+++ b/Algorithms.Tests/LinearAlgebra/Distances/ManhattanTests.cs
@@ -8,12 +8,11 @@ namespace Algorithms.Tests.LinearAlgebra.Distances;
 public class ManhattanTests
 {
     /// <summary>
-    /// Test the result given by Manhattan distance function. 
+    /// Test the result given by Manhattan distance function.
     /// </summary>
     /// <param name="point1">Origin point.</param>
     /// <param name="point2">Target point.</param>
     /// <param name="expectedDistance">Expected result.</param>
-    [Test]
     [TestCase(new[] { 1.5 }, new[] { -1.0 }, 2.5)]
     [TestCase(new[] { 2.0, 3.0 }, new[] { -1.0, 5.0 }, 5)]
     [TestCase(new[] { 1.0, 2.0, 3.0 }, new[] { 1.0, 2.0, 3.0 }, 0)]
@@ -28,7 +27,6 @@ public class ManhattanTests
     /// </summary>
     /// <param name="point1">First point of N dimensions.</param>
     /// <param name="point2">Second point of M dimensions, M != N.</param>
-    [Test]
     [TestCase(new[] { 2.0, 3.0 }, new[] { -1.0 })]
     [TestCase(new[] { 1.0 }, new[] { 1.0, 2.0, 3.0 })]
     public void DistanceThrowsArgumentExceptionOnDifferentPointDimensions(double[] point1, double[] point2)

--- a/Algorithms.Tests/ModularArithmetic/ExtendedEuclideanAlgorithmTest.cs
+++ b/Algorithms.Tests/ModularArithmetic/ExtendedEuclideanAlgorithmTest.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.ModularArithmetic;
 
 public static class ExtendedEuclideanAlgorithmTest
 {
-    [Test]
     [TestCase(240, 46, 2, -9, 47)]
     [TestCase(46, 240, 2, 47, -9)]
     [TestCase(2, 3, 1, -1, 1)]
@@ -29,7 +28,6 @@ public static class ExtendedEuclideanAlgorithmTest
         Assert.AreEqual(expectedBezoutOfB, eeaResult.bezoutB);
     }
 
-    [Test]
     [TestCase(240, 46, 2, -9, 47)]
     [TestCase(46, 240, 2, 47, -9)]
     [TestCase(2, 3, 1, -1, 1)]

--- a/Algorithms.Tests/ModularArithmetic/ModularMultiplicativeInverseTest.cs
+++ b/Algorithms.Tests/ModularArithmetic/ModularMultiplicativeInverseTest.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.ModularArithmetic;
 
 public static class ModularMultiplicativeInverseTest
 {
-    [Test]
     [TestCase(2, 3, 2)]
     [TestCase(1, 1, 0)]
     [TestCase(13, 17, 4)]
@@ -20,7 +19,6 @@ public static class ModularMultiplicativeInverseTest
         Assert.AreEqual(expected, inverse);
     }
 
-    [Test]
     [TestCase(46, 240)]
     [TestCase(0, 17)]
     [TestCase(17, 0)]
@@ -36,7 +34,6 @@ public static class ModularMultiplicativeInverseTest
         _ = Assert.Throws<ArithmeticException>(Act);
     }
 
-    [Test]
     [TestCase(2, 3, 2)]
     [TestCase(1, 1, 0)]
     [TestCase(13, 17, 4)]
@@ -49,7 +46,6 @@ public static class ModularMultiplicativeInverseTest
         Assert.AreEqual(new BigInteger(expected), inverse);
     }
 
-    [Test]
     [TestCase(46, 240)]
     [TestCase(0, 17)]
     [TestCase(17, 0)]

--- a/Algorithms.Tests/Numeric/AliquotSumCalculatorTests.cs
+++ b/Algorithms.Tests/Numeric/AliquotSumCalculatorTests.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class AliquotSumCalculatorTests
 {
-    [Test]
     [TestCase(1, 0)]
     [TestCase(3, 1)]
     [TestCase(25, 6)]
@@ -23,7 +22,6 @@ public static class AliquotSumCalculatorTests
         result.Should().Be(expectedSum);
     }
 
-    [Test]
     [TestCase(-2)]
     public static void CalculateSum_NegativeInput_ExceptionIsThrown(int number)
     {

--- a/Algorithms.Tests/Numeric/AmicableNumbersTest.cs
+++ b/Algorithms.Tests/Numeric/AmicableNumbersTest.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class AmicableNumbersTest
 {
-    [Test]
     [TestCase(220, 284)]
     [TestCase(1184, 1210)]
     [TestCase(2620, 2924)]

--- a/Algorithms.Tests/Numeric/BinomialCoefficientTests.cs
+++ b/Algorithms.Tests/Numeric/BinomialCoefficientTests.cs
@@ -20,7 +20,6 @@ public static class BinomialCoefficientTests
         Assert.AreEqual(new BigInteger(expected), result);
     }
 
-    [Test]
     [TestCase(3, 7)]
     public static void TeoremCalculateThrowsException(int n, int k)
     {

--- a/Algorithms.Tests/Numeric/Factorization/TrialDivisionFactorizerTests.cs
+++ b/Algorithms.Tests/Numeric/Factorization/TrialDivisionFactorizerTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric.Factorization;
 
 public static class TrialDivisionFactorizerTests
 {
-    [Test]
     [TestCase(2)]
     [TestCase(3)]
     [TestCase(29)]
@@ -22,7 +21,6 @@ public static class TrialDivisionFactorizerTests
         Assert.IsFalse(success);
     }
 
-    [Test]
     [TestCase(4, 2)]
     [TestCase(6, 2)]
     [TestCase(8, 2)]

--- a/Algorithms.Tests/Numeric/GreatestCommonDivisor/BinaryGreatestCommonDivisorFinderTests.cs
+++ b/Algorithms.Tests/Numeric/GreatestCommonDivisor/BinaryGreatestCommonDivisorFinderTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric.GreatestCommonDivisor;
 
 public static class BinaryGreatestCommonDivisorFinderTests
 {
-    [Test]
     [TestCase(2, 3, 1)]
     [TestCase(1, 1, 1)]
     [TestCase(13, 17, 1)]

--- a/Algorithms.Tests/Numeric/GreatestCommonDivisor/EuclideanGreatestCommonDivisorFinderTests.cs
+++ b/Algorithms.Tests/Numeric/GreatestCommonDivisor/EuclideanGreatestCommonDivisorFinderTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric.GreatestCommonDivisor;
 
 public static class EuclideanGreatestCommonDivisorFinderTests
 {
-    [Test]
     [TestCase(2, 3, 1)]
     [TestCase(1, 1, 1)]
     [TestCase(13, 17, 1)]

--- a/Algorithms.Tests/Numeric/KeithNumberTest.cs
+++ b/Algorithms.Tests/Numeric/KeithNumberTest.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class KeithNumberTest
 {
-    [Test]
     [TestCase(14)]
     [TestCase(47)]
     [TestCase(197)]
@@ -20,7 +19,6 @@ public static class KeithNumberTest
         Assert.IsTrue(result);
     }
 
-    [Test]
     [TestCase(-2)]
     public static void KeithNumberShouldThrowEx(int number)
     {

--- a/Algorithms.Tests/Numeric/ModularExponentiationTest.cs
+++ b/Algorithms.Tests/Numeric/ModularExponentiationTest.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Numeric;
 
 public class ModularExponentiationTest
 {
-    [Test]
     [TestCase(3, 6, 11, 3)]
     [TestCase(5, 3, 13, 8)]
     [TestCase(2, 7, 17, 9)]

--- a/Algorithms.Tests/Numeric/NarcissisticNumberTest.cs
+++ b/Algorithms.Tests/Numeric/NarcissisticNumberTest.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class NarcissisticNumberTest
 {
-    [Test]
     [TestCase(2, ExpectedResult = true)]
     [TestCase(3, ExpectedResult = true)]
     [TestCase(28, ExpectedResult = false)]

--- a/Algorithms.Tests/Numeric/PerfectNumberTest.cs
+++ b/Algorithms.Tests/Numeric/PerfectNumberTest.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class PerfectNumberTests
 {
-    [Test]
     [TestCase(6)]
     [TestCase(28)]
     [TestCase(496)]
@@ -22,7 +21,6 @@ public static class PerfectNumberTests
         Assert.IsTrue(result);
     }
 
-    [Test]
     [TestCase(-2)]
     public static void PerfectNumberShouldThrowEx(int number)
     {

--- a/Algorithms.Tests/Numeric/PerfectSquareTest.cs
+++ b/Algorithms.Tests/Numeric/PerfectSquareTest.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Numeric;
 
 public static class PerfectSquareTests
 {
-    [Test]
     [TestCase(-4, ExpectedResult = false)]
     [TestCase(4, ExpectedResult = true)]
     [TestCase(9, ExpectedResult = true)]

--- a/Algorithms.Tests/Other/FermatPrimeCheckerTests.cs
+++ b/Algorithms.Tests/Other/FermatPrimeCheckerTests.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Other;
 
 public static class FermatPrimeCheckerTests
 {
-    [Test]
     [TestCase(5, true)]
     [TestCase(2633, true)]
     [TestCase(9439, true)]

--- a/Algorithms.Tests/Other/GeoLocationTests.cs
+++ b/Algorithms.Tests/Other/GeoLocationTests.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Other;
 
 public static class GeoLocationTests
 {
-    [Test]
     [TestCase(53.430488d, -2.96129d, 53.430488d, -2.96129d, 0d)]
     [TestCase(53.430971d, -2.959806d, 53.430242d, -2.960830d, 105d)]
     public static void CalculateDistanceFromLatLngTest(

--- a/Algorithms.Tests/Other/Int2BinaryTests.cs
+++ b/Algorithms.Tests/Other/Int2BinaryTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Other;
 
 public static class Int2BinaryTests
 {
-    [Test]
     [TestCase((ushort)0, "0000000000000000")]
     [TestCase((ushort)0b1, "0000000000000001")]
     [TestCase((ushort)0b0001010100111000, "0001010100111000")]
@@ -24,7 +23,6 @@ public static class Int2BinaryTests
     }
 
 
-    [Test]
     [TestCase((uint)0, "00000000000000000000000000000000")]
     [TestCase((uint)0b1, "00000000000000000000000000000001")]
     [TestCase((uint)0b0001010100111000, "00000000000000000001010100111000")]
@@ -43,7 +41,6 @@ public static class Int2BinaryTests
         Assert.AreEqual(expected, result);
     }
 
-    [Test]
     [TestCase((ulong)0, "0000000000000000000000000000000000000000000000000000000000000000")]
     [TestCase((ulong)0b1, "0000000000000000000000000000000000000000000000000000000000000001")]
     [TestCase((ulong)0b0001010100111000, "0000000000000000000000000000000000000000000000000001010100111000")]

--- a/Algorithms.Tests/Other/LuhnTests.cs
+++ b/Algorithms.Tests/Other/LuhnTests.cs
@@ -8,7 +8,6 @@ namespace Algorithms.Tests.Other;
 /// </summary>
 public class LuhnTests
 {
-    [Test]
     [TestCase("89014103211118510720")] // ICCID
     [TestCase("071052120")] // Social Security Code
     [TestCase("449125546588769")] // IMEI
@@ -25,7 +24,6 @@ public class LuhnTests
         Assert.True(validate);
     }
 
-    [Test]
     [TestCase("89012104211118510720")] // ICCID
     [TestCase("021053120")] // Social Security Code
     [TestCase("449145545588969")] // IMEI
@@ -42,7 +40,6 @@ public class LuhnTests
         Assert.False(validate);
     }
 
-    [Test]
     [TestCase("x9012104211118510720")] // ICCID
     [TestCase("0210x3120")] // Social Security Code
     [TestCase("44914554558896x")] // IMEI

--- a/Algorithms.Tests/Other/RGBHSVConversionTest.cs
+++ b/Algorithms.Tests/Other/RGBHSVConversionTest.cs
@@ -29,7 +29,6 @@ public static class RgbHsvConversionTest
     }
 
     // expected RGB-values taken from https://www.rapidtables.com/convert/color/hsv-to-rgb.html
-    [Test]
     [TestCase(0, 0, 0, 0, 0, 0)]
     [TestCase(0, 0, 1, 255, 255, 255)]
     [TestCase(0, 1, 1, 255, 0, 0)]
@@ -55,7 +54,6 @@ public static class RgbHsvConversionTest
     }
 
     // Parameters of test-cases for TestRGBOutput reversed
-    [Test]
     [TestCase(0, 0, 0, 0, 0, 0)]
     [TestCase(255, 255, 255, 0, 0, 1)]
     [TestCase(255, 0, 0, 0, 1, 1)]

--- a/Algorithms.Tests/Problems/DynamicProgramming/LevenshteinDistance/LevenshteinDistanceTests.cs
+++ b/Algorithms.Tests/Problems/DynamicProgramming/LevenshteinDistance/LevenshteinDistanceTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.DynamicProgramming
 {
     public class LevenshteinDistanceTests
     {
-        [Test]
         [TestCase("kitten", "sitting", 3)]
         [TestCase("bob", "bond", 2)]
         [TestCase("algorithm", "logarithm", 3)]

--- a/Algorithms.Tests/Strings/GeneralStringAlgorithmsTests.cs
+++ b/Algorithms.Tests/Strings/GeneralStringAlgorithmsTests.cs
@@ -6,7 +6,6 @@ namespace Algorithms.Tests.Strings
 {
     public static class GeneralStringAlgorithmsTests
     {
-        [Test]
         [TestCase("Griffith", 'f', 2)]
         [TestCase("Randomwoooord", 'o', 4)]
         [TestCase("Control", 'C', 1)]

--- a/Algorithms.Tests/Strings/PalindromeTests.cs
+++ b/Algorithms.Tests/Strings/PalindromeTests.cs
@@ -5,7 +5,6 @@ namespace Algorithms.Tests.Strings
 {
     public static class PalindromeTests
     {
-        [Test]
         [TestCase("Anna")]
         [TestCase("A Santa at Nasa")]
         public static void TextIsPalindrome_TrueExpected(string text)
@@ -18,7 +17,6 @@ namespace Algorithms.Tests.Strings
             Assert.True(isPalindrome);
         }
 
-        [Test]
         [TestCase("hallo")]
         [TestCase("Once upon a time")]
         public static void TextNotPalindrome_FalseExpected(string text)

--- a/Algorithms.Tests/Strings/Similarity/HammingDistanceTests.cs
+++ b/Algorithms.Tests/Strings/Similarity/HammingDistanceTests.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Strings
 {
     public class HammingDistanceTests
     {
-        [Test]
         [TestCase("equal", "equal", 0)]
         [TestCase("dog", "dig", 1)]
         [TestCase("12345", "abcde", 5)]

--- a/Algorithms.Tests/Strings/Similarity/JaroSimilarityTests.cs
+++ b/Algorithms.Tests/Strings/Similarity/JaroSimilarityTests.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Strings
 {
     public class JaroSimilarityTests
     {
-        [Test]
         [TestCase("equal", "equal", 1)]
         [TestCase("abc", "123", 0)]
         [TestCase("FAREMVIEL", "FARMVILLE", 0.88d)]

--- a/Algorithms.Tests/Strings/Similarity/JaroWinklerDistanceTests.cs
+++ b/Algorithms.Tests/Strings/Similarity/JaroWinklerDistanceTests.cs
@@ -7,7 +7,6 @@ namespace Algorithms.Tests.Strings
 {
     public class JaroWinklerDistanceTests
     {
-        [Test]
         [TestCase("equal", "equal", 0)]
         [TestCase("abc", "123", 1)]
         [TestCase("Winkler", "Welfare", 0.33)]

--- a/DataStructures.Tests/Graph/DirectedWeightedGraphTests.cs
+++ b/DataStructures.Tests/Graph/DirectedWeightedGraphTests.cs
@@ -10,7 +10,6 @@ namespace DataStructures.Tests.Graph;
 [TestFixture]
 public class DirectedWeightedGraphTests
 {
-    [Test]
     [TestCase(-1)]
     [TestCase(-2)]
     [TestCase(-3)]
@@ -22,7 +21,6 @@ public class DirectedWeightedGraphTests
             .WithMessage("Graph capacity should always be a non-negative integer.");
     }
 
-    [Test]
     [TestCase(1)]
     [TestCase(10)]
     [TestCase(20)]

--- a/DataStructures.Tests/Hashing/NumberTheory/PrimeNumberTests.cs
+++ b/DataStructures.Tests/Hashing/NumberTheory/PrimeNumberTests.cs
@@ -93,7 +93,6 @@ public static class PrimeNumberTests
         new object[] { 10, 1, true, 7 }
     };
 
-    [Test]
     [TestCaseSource("IsPrimeSource")]
     public static void IsPrimeTest(int number, bool expected)
     {
@@ -101,7 +100,6 @@ public static class PrimeNumberTests
         Assert.AreEqual(expected, actual);
     }
 
-    [Test]
     [TestCaseSource("NextPrimeSource")]
     public static void NextPrimeTest(int number, int factor, bool desc, int expected)
     {

--- a/DataStructures.Tests/Heap/MinMaxHeapTests.cs
+++ b/DataStructures.Tests/Heap/MinMaxHeapTests.cs
@@ -34,7 +34,6 @@ public static class MinMaxHeapTests
         Assert.AreEqual("aaaa", mmh.GetMax());
     }
 
-    [Test]
     [TestCaseSource("CollectionsSource")]
     public static void AddTest<T>(IEnumerable<T> collection)
     {
@@ -52,7 +51,6 @@ public static class MinMaxHeapTests
         Assert.AreEqual(collection.Count(), mmh.Count);
     }
 
-    [Test]
     [TestCaseSource("CollectionsSource")]
     public static void ExtractMaxTest<T>(IEnumerable<T> collection)
     {
@@ -69,7 +67,6 @@ public static class MinMaxHeapTests
         Assert.AreEqual(collection.Count() - 1, mmh.Count);
     }
 
-    [Test]
     [TestCaseSource("CollectionsSource")]
     public static void ExtractMinTest<T>(IEnumerable<T> collection)
     {
@@ -87,7 +84,6 @@ public static class MinMaxHeapTests
     }
 
 
-    [Test]
     [TestCaseSource("CollectionsSource")]
     public static void GetMaxTest<T>(IEnumerable<T> collection)
     {
@@ -100,7 +96,6 @@ public static class MinMaxHeapTests
         Assert.AreEqual(collection.Max(), maxValue);
     }
 
-    [Test]
     [TestCaseSource("CollectionsSource")]
     public static void GetMinTest<T>(IEnumerable<T> collection)
     {

--- a/DataStructures.Tests/ScapegoatTree/ScapegoatTreeNodeTests.cs
+++ b/DataStructures.Tests/ScapegoatTree/ScapegoatTreeNodeTests.cs
@@ -7,7 +7,6 @@ namespace DataStructures.Tests.ScapegoatTree;
 [TestFixture]
 public class ScapegoatTreeNodeTests
 {
-    [Test]
     [TestCase(2,1)]
     [TestCase("B", "A")]
     public void RightSetter_OtherKeyPrecedesRightKey_ThrowsException<TKey>(TKey a, TKey b)
@@ -19,7 +18,6 @@ public class ScapegoatTreeNodeTests
         Assert.Throws<ArgumentException>(() => instance.Right = other);
     }
 
-    [Test]
     [TestCase(1,2)]
     [TestCase("A","B")]
     public void RightSetter_OtherKeyFollowsRightKey_AddsChild<TKey>(TKey a, TKey b)
@@ -31,7 +29,6 @@ public class ScapegoatTreeNodeTests
         Assert.DoesNotThrow(() => instance.Right = other);
     }
 
-    [Test]
     [TestCase(1,2)]
     [TestCase("A","B")]
     public void LeftSetter_OtherKeyFollowsLeftKey_ThrowsException<TKey>(TKey a, TKey b)
@@ -43,7 +40,6 @@ public class ScapegoatTreeNodeTests
         Assert.Throws<ArgumentException>(() => instance.Left = other);
     }
 
-    [Test]
     [TestCase(2,1)]
     [TestCase("B", "A")]
     public void LeftSetter_OtherKeyPrecedesLeftKey_AddsChild<TKey>(TKey a, TKey b)
@@ -55,7 +51,6 @@ public class ScapegoatTreeNodeTests
         Assert.DoesNotThrow(() => instance.Left = other);
     }
 
-    [Test]
     [TestCase(1,2)]
     [TestCase("A","B")]
     public void CompareTo_InstanceKeyPrecedesOtherKey_ReturnsMinusOne<TKey>(TKey a, TKey b)
@@ -69,7 +64,6 @@ public class ScapegoatTreeNodeTests
         Assert.AreEqual(result, -1);
     }
 
-    [Test]
     [TestCase(2, 1)]
     [TestCase("B","A")]
     public void CompareTo_InstanceKeyFollowsOtherKey_ReturnsOne<TKey>(TKey a, TKey b)
@@ -83,7 +77,6 @@ public class ScapegoatTreeNodeTests
         Assert.AreEqual(result, 1);
     }
 
-    [Test]
     [TestCase(1, 1)]
     [TestCase("A","A")]
     public void CompareTo_InstanceKeyEqualsOtherKey_ReturnsZero<TKey>(TKey a, TKey b)

--- a/DataStructures.Tests/ScapegoatTree/ScapegoatTreeTests.cs
+++ b/DataStructures.Tests/ScapegoatTree/ScapegoatTreeTests.cs
@@ -31,7 +31,6 @@ public class ScapegoatTreeTests
         Assert.AreEqual(expected, tree.Alpha);
     }
 
-    [Test]
     [TestCase(1.1)]
     [TestCase(0.4)]
     public void Constructor_AlphaParameterIsInvalid_ThrowsException(double alpha)
@@ -113,7 +112,6 @@ public class ScapegoatTreeTests
         Assert.AreEqual(1, result!.Key);
     }
 
-    [Test]
     [TestCase(-2)]
     [TestCase(3)]
     public void Search_KeyIsNotPresent_ReturnsNull(int key)
@@ -262,7 +260,6 @@ public class ScapegoatTreeTests
         Assert.AreEqual(2, tree.MaxSize);
     }
 
-    [Test]
     [TestCase(3, new[]{2,5,1,6}, -1, 0.5)]
     public void Insert_TreeIsUnbalanced_RebuildsTree(int root, int[] keys, int candidate, double alpha)
     {
@@ -281,7 +278,6 @@ public class ScapegoatTreeTests
         Assert.Throws<SuccessException>(() => tree.Insert(candidate));
     }
 
-    [Test]
     [TestCase(20, new[]{10,30,5,11,29,40,50, 1, 12}, new[]{50,40,30,29}, 0.7)]
     public void Delete_TreeIsUnbalanced_BalancesTree(int root, int[] keys, int[] candidates, double alpha)
     {
@@ -306,7 +302,6 @@ public class ScapegoatTreeTests
         });
     }
 
-    [Test]
     [TestCase(20, new[]{10,30,5,11,29,40,50}, 10, 1)]
     public void Delete_TreeIsUnbalanced_MaxSizeEqualsSize(int root, int[] keys, int candidate, double alpha)
     {
@@ -326,7 +321,6 @@ public class ScapegoatTreeTests
         Assert.AreEqual(tree.Size, tree.MaxSize);
     }
 
-    [Test]
     [TestCase(3, new[]{2,5,1,6}, -1, 0.5)]
     [TestCase(3, new[]{2,5,1,6}, 7, 0.5)]
     public void Insert_TreeIsUnbalanced_BalancesTree(int root, int[] keys, int candidate, double alpha)


### PR DESCRIPTION
I'm removing those attributes because they are redundant. NUnit can already figure out that those are tests based on `TestCase` attribute.

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [ ] I have added comments to hard-to-understand areas of my code
- [ ] I have made corresponding changes to the README.md
