### PR TITLE
used a different way to split the block into 32 bits

### DIFF
--- a/Algorithms/Encoders/FeistelCipher.cs
+++ b/Algorithms/Encoders/FeistelCipher.cs
@@ -35,10 +35,11 @@ public class FeistelCipher : IEncoder<uint>
         foreach (ulong block in blocksListPlain)
         {
             uint temp = 0;
-
-            // decompose a block to two subblocks 0x0123456789ABCDEF => 0x01234567 & 0x89ABCDEF
-            uint rightSubblock = (uint)(block & 0x00000000FFFFFFFF);
-            uint leftSubblock = (uint)(block >> 32);
+            // the BitConverter Method provides More readability
+            //splitting the block into 2 32-bit left and right blocks 
+            byte[] blockBytes = BitConverter.GetBytes(block);
+            uint rightSubblock = BitConverter.ToUInt32(blockBytes, 0);
+            uint leftSubblock = BitConverter.ToUInt32(blockBytes, 4);
 
             uint roundKey;
 
@@ -82,10 +83,11 @@ public class FeistelCipher : IEncoder<uint>
         foreach (ulong block in blocksListEncoded)
         {
             uint temp = 0;
-
-            // decompose a block to two subblocks 0x0123456789ABCDEF => 0x01234567 & 0x89ABCDEF
-            uint rightSubblock = (uint)(block & 0x00000000FFFFFFFF);
-            uint leftSubblock = (uint)(block >> 32);
+            // the BitConverter Method provides More readability
+            //splitting the block into 2 32-bit left and right blocks 
+            byte[] blockBytes = BitConverter.GetBytes(block);
+            uint rightSubblock = BitConverter.ToUInt32(blockBytes, 0);
+            uint leftSubblock = BitConverter.ToUInt32(blockBytes, 4);
 
             // Feistel "network" - decoding, the order of rounds and operations on the blocks is reverted
             uint roundKey;


### PR DESCRIPTION
I did this because the bitwise operations maybe not very readable  specially for beginners

<!--
Please include a summary of the change.
Please also include relevant motivation and context (if applicable).
Put 'x' in between square brackets to mark an item as complete.
[x] means checked checkbox
[ ] means unchecked checkbox
-->

- [x] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code
- [ ] I have made corresponding changes to the README.md
