### PR TITLE
chore: upload coverage report using `CODECOV_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,19 @@ jobs:
         run: dotnet build --no-restore
       - name: Test
         run: dotnet test --no-restore --collect "XPlat Code Coverage"
-      - name: Upload code coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to codecov (tokenless)
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+      - name: Upload coverage to codecov (with token)
+        if: >
+          github.repository == 'TheAlgorithms/C-Sharp' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
<!--
Please include a summary of the change.
Please also include relevant motivation and context (if applicable).
Put 'x' in between square brackets to mark an item as complete.
[x] means checked checkbox
[ ] means unchecked checkbox
-->

Closes #453. Uses the same logic as in TheAlgorithms/Java#5100:
- the _tokenless_ upload is used for PRs from forks,
- the upload with token is used only for PRs and pushes within this repository.

 Similar to TheAlgorithms/Rust#670.

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] ~New and existing unit tests pass locally with my changes~
- [x] ~Comments in areas I changed are up to date~
- [x] ~I have added comments to hard-to-understand areas of my code~
- [x] ~I have made corresponding changes to the README.md~
