### PR TITLE
Add Minkowski distance algorithm

### DIFF
--- a/Algorithms.Tests/LinearAlgebra/Distances/MinkowskiTests.cs
+++ b/Algorithms.Tests/LinearAlgebra/Distances/MinkowskiTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using Algorithms.LinearAlgebra.Distances;
+using FluentAssertions;
+using System;
+
+namespace Algorithms.Tests.LinearAlgebra.Distances;
+
+public class MinkowskiTests
+{
+    [TestCase(new[] { 2.0, 3.0 }, new[] { -1.0, 5.0 }, 1, 5.0)] // Simulate Manhattan condition
+    [TestCase(new[] { 7.0, 4.0, 3.0 }, new[] { 17.0, 6.0, 2.0 }, 2, 10.247)] // Simulate Euclidean condition
+    [TestCase(new[] { 1.0, 2.0, 3.0, 4.0 }, new[] { 1.75, 2.25, -3.0, 0.5 }, 20, 6.0)] // Simulate Chebyshev condition
+    [TestCase(new[] { 1.0, 1.0, 9.0 }, new[] { 2.0, 2.0, -5.2 }, 3, 14.2)]
+    [TestCase(new[] { 1.0, 2.0, 3.0 }, new[] { 1.0, 2.0, 3.0 }, 5, 0.0)]
+    public void DistanceTest(double[] point1, double[] point2, int order, double expectedDistance)
+    {
+        Minkowski.Distance(point1, point2, order).Should().BeApproximately(expectedDistance, 0.01);
+    }
+
+    [TestCase(new[] { 2.0, 3.0 }, new[] { -1.0 }, 2)]
+    [TestCase(new[] { 1.0 }, new[] { 1.0, 2.0, 3.0 }, 1)]
+    [TestCase(new[] { 1.0, 1.0 }, new[] { 2.0, 2.0 }, 0)]
+    public void DistanceThrowsArgumentExceptionOnInvalidInput(double[] point1, double[] point2, int order)
+    {
+        Action action = () => Minkowski.Distance(point1, point2, order);
+        action.Should().Throw<ArgumentException>();
+    }
+}

--- a/Algorithms/LinearAlgebra/Distances/Minkowski.cs
+++ b/Algorithms/LinearAlgebra/Distances/Minkowski.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+
+namespace Algorithms.LinearAlgebra.Distances;
+
+/// <summary>
+/// Implementation of Minkowski distance.
+/// It is the sum of the lengths of the projections of the line segment between the points onto the
+/// coordinate axes, raised to the power of the order and then taking the p-th root.
+/// For the case of order = 1, the Minkowski distance degenerates to the Manhattan distance,
+/// for order = 2, the usual Euclidean distance is obtained and for order = infinity, the Chebyshev distance is obtained.
+/// </summary>
+public static class Minkowski
+{
+    /// <summary>
+    /// Calculate Minkowski distance for two N-Dimensional points.
+    /// </summary>
+    /// <param name="point1">First N-Dimensional point.</param>
+    /// <param name="point2">Second N-Dimensional point.</param>
+    /// <param name="order">Order of the Minkowski distance.</param>
+    /// <returns>Calculated Minkowski distance.</returns>
+    public static double Distance(double[] point1, double[] point2, int order)
+    {
+        if (order < 1)
+        {
+            throw new ArgumentException("The order must be greater than or equal to 1.");
+        }
+
+        if (point1.Length != point2.Length)
+        {
+            throw new ArgumentException("Both points should have the same dimensionality");
+        }
+
+        // distance = (|x1-y1|^p + |x2-y2|^p + ... + |xn-yn|^p)^(1/p)
+        return Math.Pow(point1.Zip(point2, (x1, x2) => Math.Pow(Math.Abs(x1 - x2), order)).Sum(), 1.0 / order);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ find more than one implementation for the same objective but using different alg
     * [Distances](./Algorithms/LinearAlgebra/Distances)
       * [Euclidean](./Algorithms/LinearAlgebra/Distances/Euclidean.cs)
       * [Manhattan](./Algorithms/LinearAlgebra/Distances/Manhattan.cs)
+      * [Minkowski](./Algorithms/LinearAlgebra/Distances/Minkowski.cs)
     * [Eigenvalue](./Algorithms/LinearAlgebra/Eigenvalue)
       * [Power Iteration](./Algorithms/LinearAlgebra/Eigenvalue/PowerIteration.cs)
   * [Modular Arithmetic](./Algorithms/ModularArithmetic)


### PR DESCRIPTION
<!--
Please include a summary of the change.
Please also include relevant motivation and context (if applicable).
Put 'x' in between square brackets to mark an item as complete.
[x] means checked checkbox
[ ] means unchecked checkbox
-->

#### Summary of the Change:
This pull request introduces the Minkowski distance algorithm, which calculates the distance between two points in an N-dimensional space for a given order. The Minkowski distance generalizes both the Manhattan distance (order = 1) and the Euclidean distance (order = 2). It is defined as the p-th root of the sum of the absolute differences raised to the power of p between the coordinates of the points. [Source](https://en.wikipedia.org/wiki/Minkowski_distance)

#### Motivation
Similar to my previous contributions, I wanted to include this algorithm since it is present in other language repositories, such as Python.

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [x] I have added comments to hard-to-understand areas of my code
- [x] I have made corresponding changes to the README.md
