### PR TITLE
Fix issue #465. Added 1 new test on TimSorterTests.cs

### DIFF
--- a/Algorithms.Tests/Sorters/Comparison/TimSorterTests.cs
+++ b/Algorithms.Tests/Sorters/Comparison/TimSorterTests.cs
@@ -66,4 +66,20 @@ public static class TimSorterTests
         // Assert
         Assert.That(correctArray, Is.EqualTo(testArray));
     }
+
+    [Test]
+    public static void SkipsEntireLeftRun()
+    {
+        // Arrange
+        var sorter = new TimSorter<int>(Settings, IntComparer);
+        var testArray = new[] { 0, 1, 2, 3, 4, 5, 100, 101, 102, 103, 104, 105 };
+        var correctArray = (int[])testArray.Clone();
+
+        // Act
+        sorter.Sort(testArray, IntComparer);
+        Array.Sort(correctArray, IntComparer);
+
+        // Assert
+        Assert.That(testArray, Is.EqualTo(correctArray));
+    }
 }


### PR DESCRIPTION
Summary of the Change:

This pull request introduces a fix for issue #465 by adding a test that skips the entire left run using pre-determined array.

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [ ] I have added comments to hard-to-understand areas of my code
- [ ] I have made corresponding changes to the README.md
