### PR TITLE
Test HashTable.Resize() directly

### DIFF
--- a/DataStructures.Tests/Hashing/HashTableTests.cs
+++ b/DataStructures.Tests/Hashing/HashTableTests.cs
@@ -469,6 +469,21 @@ public class HashTableTests
     }
 
     [Test]
+    public void Resize_HandlesNegativeIndexCorrectly()
+    {
+        // Arrange
+        var hashTable = new HashTable<NegativeHashKey, string>(2);
+        var key = new NegativeHashKey(111);
+        hashTable.Add(key, "Value");
+
+        // Act
+        hashTable.Resize();
+
+        // Assert
+        Assert.That(hashTable[key], Is.EqualTo("Value"));
+    }
+
+    [Test]
     public void Add_ShouldTriggerResize_WhenThresholdExceeded()
     {
         // Arrange


### PR DESCRIPTION
Just call resize with a negative key to trigger line 300 and actually improve the coverage
See issue #465 

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Comments in areas I changed are up to date
- [ ] I have added comments to hard-to-understand areas of my code
- [ ] I have made corresponding changes to the README.md
